### PR TITLE
Component ordering

### DIFF
--- a/src/components/ServiceHealth/ServiceDetails.tsx
+++ b/src/components/ServiceHealth/ServiceDetails.tsx
@@ -1,20 +1,55 @@
 import type { FunctionComponent, ReactNode } from "react";
+import { useState } from "react"; // Import useState directly
 
 interface ServiceDetailsProps {
   disruptions: number;
   operational: number;
+  onOperationalClick: () => void; // added click handler prop
+  onDisruptionsClick: () => void; // added click handler prop
 }
 
-const ServiceDetails: FunctionComponent<ServiceDetailsProps> = ({ disruptions, operational }) => {
+const ServiceDetails: FunctionComponent<ServiceDetailsProps> = ({
+  disruptions,
+  operational,
+  onOperationalClick,
+  onDisruptionsClick,
+}) => {
+  const [isDisruptionsClicked, setIsDisruptionsClicked] = useState(false);
+  const [isOperationalClicked, setIsOperationalClicked] = useState(false);
+
+  const handleDisruptionsClick = () => {
+    onDisruptionsClick();
+    setIsDisruptionsClicked(true);
+    setIsOperationalClicked(false); // Un-underline Operational
+  };
+
+  const handleOperationalClick = () => {
+    onOperationalClick();
+    setIsOperationalClicked(true);
+    setIsDisruptionsClicked(false); // Un-underline Disruptions
+  };
+
   return (
     <div className="font-museoModerno grid grid-cols-[3fr_1fr] text-right mx-auto md:grid-cols-2 col-start-1 col-span-6 md:col-start-4 md:col-span-3 gap-[5vh] row-start-3 row-span-2 md:row-start-3 md:row-span-3 px-10 content-around text-3xl text-slate-200">
-      <span className={disruptions > 0 ? "text-red-400 font-bold underline" : ""}>Disruptions</span>
+      <span
+        onClick={handleDisruptionsClick}
+        className={`cursor-pointer  ${disruptions > 0 ? "text-red-400 font-bold" : ""} ${
+          isDisruptionsClicked ? "underline" : ""
+        }`}
+      >
+        Disruptions
+      </span>
       <span className={`flex items-center ${disruptions > 0 ? "text-red-400 font-bold" : ""}`}>
         {disruptions}
       </span>
       <span>Recently Resolved</span>
       <span className="flex items-center">0</span>
-      <span>Fully Operational</span>
+      <span
+        onClick={handleOperationalClick}
+        className={`cursor-pointer ${isOperationalClicked ? "underline" : ""}`}
+      >
+        Fully Operational
+      </span>
       <span className="flex items-center">{operational}</span>
     </div>
   );

--- a/src/components/ServiceHealth/ServiceList.tsx
+++ b/src/components/ServiceHealth/ServiceList.tsx
@@ -6,9 +6,13 @@ type ServiceListProps = {
 };
 
 const ServiceList = (props: Readonly<ServiceListProps>) => {
+  const sortedList = [...props.list].sort((a, b) =>
+    a.healthy === b.healthy ? 0 : a.healthy ? 1 : -1
+  );
+
   return (
     <div className="flex flex-col w-[25rem] gap-3 h-full mx-auto items-center overflow-y-auto">
-      {props.list.map((service, i) => (
+      {sortedList.map((service, i) => (
         <ServiceHealth
           key={service.name + i}
           name={service.name}

--- a/src/components/ServiceHealth/ServiceList.tsx
+++ b/src/components/ServiceHealth/ServiceList.tsx
@@ -3,20 +3,25 @@ import { type Service } from "@/lib/utils";
 
 type ServiceListProps = {
   list: Service[];
+  sortHealthyFirst?: boolean; // add sort order group
 };
 
-const ServiceList = (props: Readonly<ServiceListProps>) => {
-  const sortedList = [...props.list].sort((a, b) => {
-    if (a.healthy === b.healthy) {
-      // If they do, they are considered equal in terms of sorting
-      return 0;
-    } else {
-      // If 'a' is healthy and 'b' is not, 'a' should come after 'b'
-      if (a.healthy) {
+const ServiceList = ({ list, sortHealthyFirst }: ServiceListProps) => {
+  const sortedList = [...list].sort((a, b) => {
+    if (sortHealthyFirst) {
+      if (a.healthy === b.healthy) {
+        return 0;
+      } else if (a.healthy && !b.healthy) {
+        return -1;
+      } else {
         return 1;
       }
-      // If 'b' is healthy and 'a' is not, 'a' should come before 'b'
-      else {
+    } else {
+      if (a.healthy === b.healthy) {
+        return 0;
+      } else if (a.healthy && !b.healthy) {
+        return 1;
+      } else {
         return -1;
       }
     }

--- a/src/components/ServiceHealth/ServiceList.tsx
+++ b/src/components/ServiceHealth/ServiceList.tsx
@@ -9,6 +9,7 @@ const ServiceList = (props: Readonly<ServiceListProps>) => {
   const sortedList = [...props.list].sort((a, b) =>
     a.healthy === b.healthy ? 0 : a.healthy ? 1 : -1
   );
+  //what is going on
 
   return (
     <div className="flex flex-col w-[25rem] gap-3 h-full mx-auto items-center overflow-y-auto">

--- a/src/components/ServiceHealth/ServiceList.tsx
+++ b/src/components/ServiceHealth/ServiceList.tsx
@@ -6,10 +6,21 @@ type ServiceListProps = {
 };
 
 const ServiceList = (props: Readonly<ServiceListProps>) => {
-  const sortedList = [...props.list].sort((a, b) =>
-    a.healthy === b.healthy ? 0 : a.healthy ? 1 : -1
-  );
-  //what is going on
+  const sortedList = [...props.list].sort((a, b) => {
+    if (a.healthy === b.healthy) {
+      // If they do, they are considered equal in terms of sorting
+      return 0;
+    } else {
+      // If 'a' is healthy and 'b' is not, 'a' should come after 'b'
+      if (a.healthy) {
+        return 1;
+      }
+      // If 'b' is healthy and 'a' is not, 'a' should come before 'b'
+      else {
+        return -1;
+      }
+    }
+  });
 
   return (
     <div className="flex flex-col w-[25rem] gap-3 h-full mx-auto items-center overflow-y-auto">

--- a/src/components/ServiceHealth/ServicesContainer.tsx
+++ b/src/components/ServiceHealth/ServicesContainer.tsx
@@ -9,6 +9,7 @@ const address = `${process.env.NEXT_PUBLIC_HOSTNAME}/api/services`;
 
 const ServicesContainer = () => {
   const [services, setServices] = useState<Service[] | null>(null);
+  const [sortHealthyFirst, setSortHealthyFirst] = useState(false); // state for sort order
 
   const disruptions = services
     ? services.reduce((sum, service) => (service.healthy ? sum : sum + 1), 0)
@@ -33,6 +34,15 @@ const ServicesContainer = () => {
     return () => clearInterval(intervalID);
   }, [fetchData]);
 
+  // fully operational sorting order
+  const toggleSortHealthyFirst = () => {
+    setSortHealthyFirst(true);
+  };
+
+  const toggleDisruptionsFirst = () => {
+    setSortHealthyFirst(false);
+  };
+
   return (
     <>
       <div className="col-start-2 col-span-4 md:col-start-1 md:col-span-3 md:mx-12 px-3 border border-slate-500 rounded-lg text-slate-200">
@@ -40,12 +50,17 @@ const ServicesContainer = () => {
       </div>
       <div className="col-start-1 col-span-6 md:col-span-3 row-start-5 row-span-1 md:row-start-3 md:row-span-4">
         {services ? (
-          <ServiceList list={services} />
+          <ServiceList list={services} sortHealthyFirst={sortHealthyFirst} />
         ) : (
           <div className="text-slate-200 w-[25rem] mx-auto">Loading...</div>
         )}
       </div>
-      <ServiceDetails disruptions={disruptions} operational={operational} />
+      <ServiceDetails
+        disruptions={disruptions}
+        operational={operational}
+        onOperationalClick={toggleSortHealthyFirst}
+        onDisruptionsClick={toggleDisruptionsFirst}
+      />
     </>
   );
 };


### PR DESCRIPTION
Closes #28 
orders disruptions at top by default
adds interactivity to sort components by health state when clicking on service details text "disruptions" and "fully operational".
