### PR TITLE
Add 30 days of history for "netlify" and "google"

### DIFF
--- a/db/seed/status_history.js
+++ b/db/seed/status_history.js
@@ -1,9 +1,30 @@
+const addSeconds = (date, s) => date.setTime(date.getTime() + (s * 1000));
+const addMinutes = (date, m) => date.setTime(date.getTime() + (m * 60 * 1000));
+const addHours = (date, h) => date.setTime(date.getTime() + (h * 60 * 60 * 1000));
+const addDays = (date, d) => date.setTime(date.getTime() + (d * 24 * 60 * 60 * 1000));
+const subtractDays = (date, d) => date.setTime(date.getTime() - (d * 24 * 60 * 60 * 1000));
+
+const randomHealth = () => Math.random() < 0.95
+
+const history = (id, startDate, days) => {
+  let h = [];
+  for (let i = 0; i < days; i += 1) {
+    for (let j = 0; j < 288; j += 1) {
+      h.push({
+        service_id: id,
+        healthy: randomHealth(),
+        time: new Date(addMinutes(startDate, 5))
+      })
+    }
+  }
+  return h;
+}
+
+const aMonthAgo = new Date(subtractDays(new Date(), 30))
+
 const STATUS_HISTORY = [
-  {
-    service_id: 1,
-    healthy: true,
-    time: new Date(),
-  },
-];
+  history(1, aMonthAgo, 30),
+  history(4, aMonthAgo, 30),
+].flat();
 
 export default STATUS_HISTORY;

--- a/src/app/status/@details/[id]/page.tsx
+++ b/src/app/status/@details/[id]/page.tsx
@@ -14,7 +14,7 @@ const StatusDetailsView = async ({ params }: { params: { id: string } }) => {
           COUNT(CASE WHEN NOT healthy THEN 1 END) AS false_count,
           COUNT(*) AS total_count
         FROM status_history
-        WHERE "time" >= current_date - interval '11 days' AND service_id = $1
+        WHERE "time" >= current_date - interval '29 days' AND service_id = $1
         GROUP BY extract('day' from "time")
       )
       SELECT


### PR DESCRIPTION
This just gives us some immediate history to work with in at least two services after we use the reset-db script.

It also updates the max number of days returned from the database in the details/[id] page.